### PR TITLE
Update provision results with Tower job status

### DIFF
--- a/operator/provisions.py
+++ b/operator/provisions.py
@@ -71,18 +71,13 @@ class Provisions(object):
         user_db_info = self.prov_data.get('user_db', {})
         student_id = user_db_info.get('user_id')
         user_manager_id = user_db_info.get('manager_id')
-        user_manager_chargeback_id  = user_db_info.get('manager_chargeback_id')
+        user_manager_chargeback_id = user_db_info.get('manager_chargeback_id')
         user_cost_center = user_db_info.get('cost_center')
 
         current_state = self.prov_data.get('current_state')
-        provision_result = 'installing'
+        provision_result = 'running'
         if current_state.startswith('provision-') and current_state != 'provision-pending':
             provision_result = self.prov_data.get('provision_result', provision_result)
-
-        if provision_result == 'failed':
-            provision_result = 'failure'
-        elif provision_result == 'successful':
-            provision_result = 'success'
 
         # TODO: Fix cloud ec2 to AWS and osp to openstack
         cloud = self.prov_data.get('cloud', 'unknown')
@@ -138,7 +133,6 @@ class Provisions(object):
             # 'guid': self.prov_data.get('guid'),
             'uuid': self.provision_uuid,
             'babylon_guid': self.prov_data.get('babylon_guid'),
-            'provision_result': provision_result,
             'account': self.prov_data.get('account', 'tests'),
             'cloud_region': self.prov_data.get('cloud_region'),
             'purpose': purpose,

--- a/operator/utils.py
+++ b/operator/utils.py
@@ -337,9 +337,12 @@ def last_lifecycle(provision_uuid):
     else:
         return None
 
-def provision_lifecycle(provision_uuid, current_state, username):
 
+def provision_lifecycle(provision_uuid, current_state, username):
     last_state = last_lifecycle(provision_uuid)
+
+    if last_state == current_state:
+        return
 
     print(f"Updating provision {provision_uuid} - last_state = {current_state}")
     current_date = datetime.now(timezone.utc)


### PR DESCRIPTION
* We are using Tower job status as the provision result
  by default Tower uses `running` as the initial status while the job is running
* Add new Anarchy event `provision-canceled`
* Fix lifecycle log for `provision-completed`
