### PR TITLE
Using service_type as the source UI to install

### DIFF
--- a/operator/operator.py
+++ b/operator/operator.py
@@ -513,9 +513,11 @@ def prepare(anarchy_subject, logger, resource_vars):
     if purpose is None:
         purpose = provision_job_vars.get('purpose', 'Development - Catalog item creation / maintenance')
 
+    service_type = 'babylon'
     if notifier:
         platform_url = notifier
         using_cloud_forms = True
+        service_type = 'cfme'
 
     if '.' in catalog_display_name:
         catalog_display_name = parse_catalog_item(catalog_display_name)
@@ -563,7 +565,8 @@ def prepare(anarchy_subject, logger, resource_vars):
         'azure_tenant': azure_tenant,
         'azure_subscription': azure_subscription,
         'using_cloud_forms': using_cloud_forms,
-        'provision_result': provision_job_status
+        'provision_result': provision_job_status,
+        'service_type': service_type
     }
 
     utils.save_provision_vars(resource_claim_uuid, resource_claim_name, resource_claim_namespace, provision)

--- a/operator/provisions.py
+++ b/operator/provisions.py
@@ -102,7 +102,7 @@ class Provisions(object):
             'workload': self.prov_data.get('workload'),
             'provision_time': self.prov_data.get('provisiontime', 0),
             'deploy_interval': self.prov_data.get('deploy_interval'),
-            'service_type': self.prov_data.get('servicetype', 'babylon'),
+            'service_type': self.prov_data.get('service_type', 'babylon'),
             'stack_retries': self.prov_data.get('stack_retries', 1),
             'opportunity': self.prov_data.get('opportunity'),
             'purpose_id': purpose_id,
@@ -122,8 +122,6 @@ class Provisions(object):
             'last_state': current_state
         }
 
-        using_cloud_forms = self.prov_data.get('using_cloud_forms', False)
-
         update_fields = {
             'student_id': student_id,
             'catalog_id': catalog_id,
@@ -142,7 +140,7 @@ class Provisions(object):
             'workload': self.prov_data.get('workload'),
             'provision_time': self.prov_data.get('provision_time', 0),
             'deploy_interval': self.prov_data.get('deploy_interval'),
-            'service_type': self.prov_data.get('servicetype', 'babylon'),
+            'service_type': self.prov_data.get('service_type', 'babylon'),
             'stack_retries': self.prov_data.get('stack_retries', 1),
             'opportunity': self.prov_data.get('opportunity'),
             'purpose_id': purpose_id,


### PR DESCRIPTION
This is a request to identify where the request to install comes from, possible values will be `cfme` or `babylon` (default).
It will be used to provide a dashboard with numbers of provisions by source UI